### PR TITLE
Feature/minyeong

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import Chart from './components/Chart';
+import ChartPage from './pages/ChartPage';
 
 function App() {
-  return <Chart />;
+  return <ChartPage />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,7 @@
-import styled from 'styled-components';
+import Chart from './components/Chart';
 
 function App() {
-  return (
-    <div>
-      <StyledBox />
-    </div>
-  );
+  return <Chart />;
 }
 
 export default App;
-
-const StyledBox = styled.div`
-  width: 300px;
-  height: 300px;
-  background-color: tomato;
-`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
-import ChartPage from './pages/ChartPage';
+import { RouterProvider } from 'react-router-dom';
+
+import router from './shared/Router';
 
 function App() {
-  return <ChartPage />;
+  return <RouterProvider router={router} />;
 }
 
 export default App;

--- a/src/apis/chartApi.ts
+++ b/src/apis/chartApi.ts
@@ -1,0 +1,7 @@
+import { IChartNestedObjects } from '../types/chartTypes';
+import instance from './instance';
+
+export const getChartApi = async (): Promise<IChartNestedObjects> => {
+  const response = await instance.get('');
+  return response.data.response;
+};

--- a/src/apis/chartApi.ts
+++ b/src/apis/chartApi.ts
@@ -1,7 +1,6 @@
-import { IChartNestedObjects } from '../types/chartTypes';
 import instance from './instance';
 
-export const getChartApi = async (): Promise<IChartNestedObjects> => {
+export const getChartApi = async () => {
   const response = await instance.get('');
   return response.data.response;
 };

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,57 +1,27 @@
-import { useEffect, useState } from 'react';
 import ReactApexChart from 'react-apexcharts';
+import { renderToString } from 'react-dom/server';
 
-import { getChartApi } from '../apis/chartApi';
-import { IChartNestedObjects, IChartSingleObject } from '../types/chartTypes';
+import { useChartData } from '../hooks/useChartData';
+import Tooltip from './Tooltip';
 
 const Chart = () => {
-  const [chartNestedObjects, setChartNestedObjects] =
-    useState<IChartNestedObjects>();
-
-  useEffect(() => {
-    getChartApi().then(response => {
-      setChartNestedObjects(response);
-    });
-  }, []);
-
-  const valueAreaArray: number[] = chartNestedObjects
-    ? Object.values(chartNestedObjects).map(
-        (item: IChartSingleObject) => item.value_area
-      )
-    : [];
-
-  const valueBarArray: number[] = chartNestedObjects
-    ? Object.values(chartNestedObjects).map(
-        (item: IChartSingleObject) => item.value_bar
-      )
-    : [];
-
-  const dateTimeArray = chartNestedObjects
-    ? Object.keys(chartNestedObjects)
-    : [];
+  const { dateTimeArray, idArray, areaArray, barArray } = useChartData();
 
   const series = [
     {
       name: 'value_bar',
       type: 'column',
-      data: valueBarArray,
+      data: barArray,
     },
     {
       name: 'value_area',
       type: 'area',
-      data: valueAreaArray,
+      data: areaArray,
     },
   ];
 
   const options = {
-    fill: {
-      type: 'solid',
-      opacity: [0.35, 1],
-    },
     labels: dateTimeArray,
-    markers: {
-      size: 0,
-    },
     yaxis: [
       {
         title: {
@@ -66,28 +36,16 @@ const Chart = () => {
       },
     ],
     tooltip: {
-      custom({
-        series,
-        seriesIndex,
-        dataPointIndex,
-        w,
-      }: {
-        series: any[];
-        seriesIndex: number;
-        dataPointIndex: number;
-        w: any;
-      }) {
-        const tooltipContent =
-          chartNestedObjects && dateTimeArray[dataPointIndex]
-            ? `<ul>
-            <li><p>id</p>: ${
-              chartNestedObjects[dateTimeArray[dataPointIndex]].id
-            }</li>
-            <li><p>value_area</p>: '${series[0][dataPointIndex]}'</li>
-            <li><p>value_bar</p>: '${series[1][dataPointIndex]}'</li>
-          </ul>`
-            : '';
-        return tooltipContent;
+      custom: ({ dataPointIndex }: { dataPointIndex: number }) => {
+        return renderToString(
+          <Tooltip
+            data={{
+              id: idArray[dataPointIndex],
+              area: barArray[dataPointIndex],
+              bar: barArray[dataPointIndex],
+            }}
+          />
+        );
       },
     },
   };

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,7 +1,98 @@
-import ApexChart from 'react-apexcharts';
+import { useEffect, useState } from 'react';
+import ReactApexChart from 'react-apexcharts';
+
+import { getChartApi } from '../apis/chartApi';
+import { IChartNestedObjects, IChartSingleObject } from '../types/chartTypes';
 
 const Chart = () => {
-  return <ApexChart />;
+  const [chartNestedObjects, setChartNestedObjects] =
+    useState<IChartNestedObjects>();
+
+  useEffect(() => {
+    getChartApi().then(response => {
+      setChartNestedObjects(response);
+    });
+  }, []);
+
+  const valueAreaArray: number[] = chartNestedObjects
+    ? Object.values(chartNestedObjects).map(
+        (item: IChartSingleObject) => item.value_area
+      )
+    : [];
+
+  const valueBarArray: number[] = chartNestedObjects
+    ? Object.values(chartNestedObjects).map(
+        (item: IChartSingleObject) => item.value_bar
+      )
+    : [];
+
+  const dateTimeArray = chartNestedObjects
+    ? Object.keys(chartNestedObjects)
+    : [];
+
+  const series = [
+    {
+      name: 'value_bar',
+      type: 'column',
+      data: valueBarArray,
+    },
+    {
+      name: 'value_area',
+      type: 'area',
+      data: valueAreaArray,
+    },
+  ];
+
+  const options = {
+    fill: {
+      type: 'solid',
+      opacity: [0.35, 1],
+    },
+    labels: dateTimeArray,
+    markers: {
+      size: 0,
+    },
+    yaxis: [
+      {
+        title: {
+          text: 'value_area',
+        },
+      },
+      {
+        opposite: true,
+        title: {
+          text: 'value_bar',
+        },
+      },
+    ],
+    tooltip: {
+      custom({
+        series,
+        seriesIndex,
+        dataPointIndex,
+        w,
+      }: {
+        series: any[];
+        seriesIndex: number;
+        dataPointIndex: number;
+        w: any;
+      }) {
+        const tooltipContent =
+          chartNestedObjects && dateTimeArray[dataPointIndex]
+            ? `<ul>
+            <li><p>id</p>: ${
+              chartNestedObjects[dateTimeArray[dataPointIndex]].id
+            }</li>
+            <li><p>value_area</p>: '${series[0][dataPointIndex]}'</li>
+            <li><p>value_bar</p>: '${series[1][dataPointIndex]}'</li>
+          </ul>`
+            : '';
+        return tooltipContent;
+      },
+    },
+  };
+
+  return <ReactApexChart type='line' options={options} series={series} />;
 };
 
 export default Chart;

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,26 +1,47 @@
+import { useEffect, useState } from 'react';
 import ReactApexChart from 'react-apexcharts';
 import { renderToString } from 'react-dom/server';
+import { useNavigate, useParams } from 'react-router-dom';
 
-import { ChartProps } from '../types/chartTypes';
+import { useChartData } from '../hooks/useChartData';
+import { YAxisData } from '../types/chartTypes';
 import Tooltip from './Tooltip';
 
-const Chart = ({
-  dateTimeArray,
-  idArray,
-  barArrayState: barArray,
-  areaArrayState: areaArray,
-  handleFilter,
-}: ChartProps) => {
+const Chart = () => {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const { dateTimeArray, idArray, areaArray, barArray } = useChartData();
+  const [barArrayState, setBarArrayState] = useState<YAxisData[]>([]);
+  const [areaArrayState, setAreaArrayState] = useState<YAxisData[]>([]);
+
+  useEffect(() => {
+    if (id !== '전체') {
+      const highlightedBarArray = barArray.map((barData, index) => {
+        const fillColor = idArray[index] === id ? '#fb00a6' : '#008FFB';
+        return { ...barData, fillColor };
+      });
+      const highlightedAreaArray = areaArray.map((areaData, index) => {
+        const fillColor = idArray[index] === id ? '#fb00a6' : '#26E7A6';
+        return { ...areaData, fillColor };
+      });
+      setBarArrayState([...highlightedBarArray]);
+      setAreaArrayState([...highlightedAreaArray]);
+    } else {
+      setBarArrayState(barArray);
+      setAreaArrayState(areaArray);
+    }
+  }, [id, barArray, areaArray, idArray]);
+
   const series = [
     {
       name: 'value_bar',
       type: 'column',
-      data: barArray,
+      data: barArrayState,
     },
     {
       name: 'value_area',
       type: 'area',
-      data: areaArray,
+      data: areaArrayState,
     },
   ];
 
@@ -31,7 +52,7 @@ const Chart = ({
     chart: {
       events: {
         dataPointSelection: (event: any, chartContext: any, config: any) =>
-          handleFilter(idArray[config.dataPointIndex]),
+          navigate(`/${idArray[config.dataPointIndex]}`),
       },
     },
     markers: {

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -3,6 +3,7 @@ import ReactApexChart from 'react-apexcharts';
 import { renderToString } from 'react-dom/server';
 import { useNavigate, useParams } from 'react-router-dom';
 
+import { commaPerThousand } from '../common/utils';
 import { useChartData } from '../hooks/useChartData';
 import { YAxisData } from '../types/chartTypes';
 import Tooltip from './Tooltip';
@@ -17,11 +18,15 @@ const Chart = () => {
   useEffect(() => {
     if (id !== '전체') {
       const highlightedBarArray = barArray.map((barData, index) => {
-        const fillColor = idArray[index] === id ? '#fb00a6' : '#008FFB';
+        const fillColor =
+          idArray[index] === id
+            ? 'rgba(0, 142, 250, 0.52)'
+            : 'rgba(0, 0, 0, 0.15)';
         return { ...barData, fillColor };
       });
       const highlightedAreaArray = areaArray.map((areaData, index) => {
-        const fillColor = idArray[index] === id ? '#fb00a6' : '#26E7A6';
+        const fillColor =
+          idArray[index] === id ? 'rgba(0, 0, 0, 0.15)' : 'rgba(0, 0, 0, 0.15)';
         return { ...areaData, fillColor };
       });
       setBarArrayState([...highlightedBarArray]);
@@ -46,6 +51,7 @@ const Chart = () => {
   ];
 
   const options = {
+    colors: ['rgba(0, 142, 250, 0.52)', '#00E396'],
     stroke: {
       show: false,
     },
@@ -56,19 +62,27 @@ const Chart = () => {
       },
     },
     markers: {
-      size: 5,
+      size: 4,
     },
     labels: dateTimeArray,
     yaxis: [
       {
-        title: {
-          text: 'value_area',
-        },
-      },
-      {
         opposite: true,
         title: {
           text: 'value_bar',
+        },
+        labels: {
+          formatter: (value: number) => commaPerThousand(Math.floor(value)),
+        },
+      },
+      {
+        max: 200,
+        colors: ['#000000', '#000000'],
+        title: {
+          text: 'value_area',
+        },
+        labels: {
+          formatter: (value: number) => commaPerThousand(Math.floor(value)),
         },
       },
     ],

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -1,12 +1,16 @@
 import ReactApexChart from 'react-apexcharts';
 import { renderToString } from 'react-dom/server';
 
-import { useChartData } from '../hooks/useChartData';
+import { ChartProps } from '../types/chartTypes';
 import Tooltip from './Tooltip';
 
-const Chart = () => {
-  const { dateTimeArray, idArray, areaArray, barArray } = useChartData();
-
+const Chart = ({
+  dateTimeArray,
+  idArray,
+  barArrayState: barArray,
+  areaArrayState: areaArray,
+  handleFilter,
+}: ChartProps) => {
   const series = [
     {
       name: 'value_bar',
@@ -21,6 +25,18 @@ const Chart = () => {
   ];
 
   const options = {
+    stroke: {
+      show: false,
+    },
+    chart: {
+      events: {
+        dataPointSelection: (event: any, chartContext: any, config: any) =>
+          handleFilter(idArray[config.dataPointIndex]),
+      },
+    },
+    markers: {
+      size: 5,
+    },
     labels: dateTimeArray,
     yaxis: [
       {
@@ -36,13 +52,24 @@ const Chart = () => {
       },
     ],
     tooltip: {
-      custom: ({ dataPointIndex }: { dataPointIndex: number }) => {
+      custom: ({
+        series,
+        dataPointIndex,
+      }: {
+        series: any;
+        seriesIndex: any;
+        dataPointIndex: number;
+        w: any;
+      }) => {
+        const valueId = idArray[dataPointIndex];
+        const valueBar = series[0][dataPointIndex];
+        const valueArea = series[1][dataPointIndex];
         return renderToString(
           <Tooltip
             data={{
-              id: idArray[dataPointIndex],
-              area: barArray[dataPointIndex],
-              bar: barArray[dataPointIndex],
+              valueId,
+              valueArea,
+              valueBar,
             }}
           />
         );

--- a/src/components/FilterBtn.tsx
+++ b/src/components/FilterBtn.tsx
@@ -1,0 +1,42 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+const FilterBtn = ({ btnName }: { btnName: string }) => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const isSelected = btnName === id;
+
+  return isSelected ? (
+    <StSelectedBtn onClick={() => navigate(`/${btnName}`)}>
+      {btnName}
+    </StSelectedBtn>
+  ) : (
+    <StNotSelectedBtn onClick={() => navigate(`/${btnName}`)}>
+      {btnName}
+    </StNotSelectedBtn>
+  );
+};
+
+export default FilterBtn;
+
+const StSelectedBtn = styled.button`
+  width: 65px;
+  height: 30px;
+  background-color: #7ac4fc;
+  padding: 5px;
+  border: 1px solid #7ac4fc;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+`;
+
+const StNotSelectedBtn = styled.button`
+  width: 65px;
+  height: 30px;
+  background-color: white;
+  padding: 5px;
+  border: 1px solid #808080;
+  color: #808080;
+  border-radius: 4px;
+  cursor: pointer;
+`;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,10 +1,14 @@
+import styled from 'styled-components';
+
 const Tooltip = ({ data }: PropsType) => {
   return (
-    <ul>
-      <li>id: {data.valueId}</li>
-      <li>value_area: {data.valueArea}</li>
-      <li>value_bar: {data.valueBar}</li>
-    </ul>
+    <StTooltipContainer>
+      <StUl>
+        <StLi>id: {data.valueId}</StLi>
+        <StLi>value_area: {data.valueArea}</StLi>
+        <StLi>value_bar: {data.valueBar}</StLi>
+      </StUl>
+    </StTooltipContainer>
   );
 };
 
@@ -17,3 +21,20 @@ type PropsType = {
 };
 
 export default Tooltip;
+
+const StLi = styled.li`
+  list-style: none;
+`;
+
+const StUl = styled.ul`
+  list-style: none;
+  padding: 0px;
+`;
+
+const StTooltipContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 50px;
+  padding: 10px;
+`;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,19 @@
+const Tooltip = ({ data }: PropsType) => {
+  return (
+    <ul>
+      <li>id: {data.id}</li>
+      <li>value_area: {data.area}</li>
+      <li>value_bar: {data.bar}</li>
+    </ul>
+  );
+};
+
+type PropsType = {
+  data: {
+    id: string;
+    area: number;
+    bar: number;
+  };
+};
+
+export default Tooltip;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,18 +1,18 @@
 const Tooltip = ({ data }: PropsType) => {
   return (
     <ul>
-      <li>id: {data.id}</li>
-      <li>value_area: {data.area}</li>
-      <li>value_bar: {data.bar}</li>
+      <li>id: {data.valueId}</li>
+      <li>value_area: {data.valueArea}</li>
+      <li>value_bar: {data.valueBar}</li>
     </ul>
   );
 };
 
 type PropsType = {
   data: {
-    id: string;
-    area: number;
-    bar: number;
+    valueId: string;
+    valueArea: number;
+    valueBar: number;
   };
 };
 

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -15,8 +15,16 @@ export const useChartData = () => {
     getChartApi().then((response: { [key: string]: ItemData }) => {
       const dateTimeArray = Object.keys(response);
       const idArray = Object.values(response).map(item => item.id);
-      const areaArray = Object.values(response).map(item => item.value_area);
-      const barArray = Object.values(response).map(item => item.value_bar);
+      const areaArray = Object.values(response).map((item, index) => ({
+        x: dateTimeArray[index],
+        y: item.value_area,
+        fillColor: '#26E7A6',
+      }));
+      const barArray = Object.values(response).map((item, index) => ({
+        x: dateTimeArray[index],
+        y: item.value_bar,
+        fillColor: '#008FFB',
+      }));
       setChartData({ dateTimeArray, idArray, areaArray, barArray });
     });
   }, []);

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+import { getChartApi } from '../apis/chartApi';
+import { ChartData, ItemData } from '../types/chartTypes';
+
+export const useChartData = () => {
+  const [chartData, setChartData] = useState<ChartData>({
+    dateTimeArray: [],
+    idArray: [],
+    areaArray: [],
+    barArray: [],
+  });
+
+  useEffect(() => {
+    getChartApi().then((response: { [key: string]: ItemData }) => {
+      const dateTimeArray = Object.keys(response);
+      const idArray = Object.values(response).map(item => item.id);
+      const areaArray = Object.values(response).map(item => item.value_area);
+      const barArray = Object.values(response).map(item => item.value_bar);
+      setChartData({ dateTimeArray, idArray, areaArray, barArray });
+    });
+  }, []);
+
+  return chartData;
+};

--- a/src/hooks/useChartData.ts
+++ b/src/hooks/useChartData.ts
@@ -18,12 +18,12 @@ export const useChartData = () => {
       const areaArray = Object.values(response).map((item, index) => ({
         x: dateTimeArray[index],
         y: item.value_area,
-        fillColor: '#26E7A6',
+        fillColor: 'rgba(0, 0, 0, 0.15)',
       }));
       const barArray = Object.values(response).map((item, index) => ({
         x: dateTimeArray[index],
         y: item.value_bar,
-        fillColor: '#008FFB',
+        fillColor: 'rgba(0, 142, 250, 0.52)',
       }));
       setChartData({ dateTimeArray, idArray, areaArray, barArray });
     });

--- a/src/hooks/useHooks.tsx
+++ b/src/hooks/useHooks.tsx
@@ -1,5 +1,0 @@
-function useHooks() {
-  return <div>useHooks</div>;
-}
-
-export default useHooks;

--- a/src/pages/ChartPage.tsx
+++ b/src/pages/ChartPage.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+
+import Chart from '../components/Chart';
+import { useChartData } from '../hooks/useChartData';
+import { YAxisData } from '../types/chartTypes';
+
+const ChartPage = () => {
+  const { dateTimeArray, idArray, areaArray, barArray } = useChartData();
+  const [barArrayState, setBarArrayState] = useState<YAxisData[]>([]);
+  const [areaArrayState, setAreaArrayState] = useState<YAxisData[]>([]);
+
+  useEffect(() => {
+    setBarArrayState(barArray);
+    setAreaArrayState(areaArray);
+  }, [barArray, areaArray]);
+
+  const uniqueIdList = [...new Set(idArray)];
+
+  const handleFilter = (selectedId: string) => {
+    const highlightedBarArray = barArray.map((barData, index) => {
+      const fillColor = idArray[index] === selectedId ? '#fb00a6' : '#008FFB';
+      return { ...barData, fillColor };
+    });
+    const highlightedAreaArray = areaArray.map((areaData, index) => {
+      const fillColor = idArray[index] === selectedId ? '#fb00a6' : '#26E7A6';
+      return { ...areaData, fillColor };
+    });
+    setBarArrayState([...highlightedBarArray]);
+    setAreaArrayState([...highlightedAreaArray]);
+  };
+
+  return (
+    <div>
+      <div>
+        {uniqueIdList.map(id => (
+          <button key={id} onClick={() => handleFilter(id)}>
+            {id}
+          </button>
+        ))}
+      </div>
+      <Chart
+        dateTimeArray={dateTimeArray}
+        idArray={idArray}
+        barArrayState={barArrayState}
+        areaArrayState={areaArrayState}
+        handleFilter={handleFilter}
+      />
+    </div>
+  );
+};
+
+export default ChartPage;

--- a/src/pages/ChartPage.tsx
+++ b/src/pages/ChartPage.tsx
@@ -1,26 +1,52 @@
-import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 
 import Chart from '../components/Chart';
+import FilterBtn from '../components/FilterBtn';
 import { useChartData } from '../hooks/useChartData';
 
 const ChartPage = () => {
   const { idArray } = useChartData();
-  const navigate = useNavigate();
 
   const filterBtnList: string[] = [...new Set(idArray)].concat('전체');
 
   return (
-    <div>
-      <div>
+    <>
+      <StHeader>Flexys</StHeader>
+      <StBtnContainer>
         {filterBtnList.map(id => (
-          <button key={id} onClick={() => navigate(`/${id}`)}>
-            {id}
-          </button>
+          <FilterBtn key={id} btnName={id} />
         ))}
-      </div>
-      <Chart />
-    </div>
+      </StBtnContainer>
+      <StChartContainer>
+        <Chart />
+      </StChartContainer>
+    </>
   );
 };
 
 export default ChartPage;
+
+const StBtnContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin: 10px;
+`;
+
+const StChartContainer = styled.div`
+  margin: 0 auto;
+  width: 70%;
+  padding: 40px;
+`;
+
+const StHeader = styled.div`
+  font-size: 2.5rem;
+  font-weight: 700;
+  font-style: italic;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 30px;
+`;

--- a/src/pages/ChartPage.tsx
+++ b/src/pages/ChartPage.tsx
@@ -1,50 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import Chart from '../components/Chart';
 import { useChartData } from '../hooks/useChartData';
-import { YAxisData } from '../types/chartTypes';
 
 const ChartPage = () => {
-  const { dateTimeArray, idArray, areaArray, barArray } = useChartData();
-  const [barArrayState, setBarArrayState] = useState<YAxisData[]>([]);
-  const [areaArrayState, setAreaArrayState] = useState<YAxisData[]>([]);
+  const { idArray } = useChartData();
+  const navigate = useNavigate();
 
-  useEffect(() => {
-    setBarArrayState(barArray);
-    setAreaArrayState(areaArray);
-  }, [barArray, areaArray]);
-
-  const uniqueIdList = [...new Set(idArray)];
-
-  const handleFilter = (selectedId: string) => {
-    const highlightedBarArray = barArray.map((barData, index) => {
-      const fillColor = idArray[index] === selectedId ? '#fb00a6' : '#008FFB';
-      return { ...barData, fillColor };
-    });
-    const highlightedAreaArray = areaArray.map((areaData, index) => {
-      const fillColor = idArray[index] === selectedId ? '#fb00a6' : '#26E7A6';
-      return { ...areaData, fillColor };
-    });
-    setBarArrayState([...highlightedBarArray]);
-    setAreaArrayState([...highlightedAreaArray]);
-  };
+  const filterBtnList: string[] = [...new Set(idArray)].concat('전체');
 
   return (
     <div>
       <div>
-        {uniqueIdList.map(id => (
-          <button key={id} onClick={() => handleFilter(id)}>
+        {filterBtnList.map(id => (
+          <button key={id} onClick={() => navigate(`/${id}`)}>
             {id}
           </button>
         ))}
       </div>
-      <Chart
-        dateTimeArray={dateTimeArray}
-        idArray={idArray}
-        barArrayState={barArrayState}
-        areaArrayState={areaArrayState}
-        handleFilter={handleFilter}
-      />
+      <Chart />
     </div>
   );
 };

--- a/src/shared/Router.tsx
+++ b/src/shared/Router.tsx
@@ -1,0 +1,18 @@
+import {
+  Navigate,
+  Route,
+  createBrowserRouter,
+  createRoutesFromElements,
+} from 'react-router-dom';
+
+import ChartPage from '../pages/ChartPage';
+
+const router = createBrowserRouter(
+  createRoutesFromElements(
+    <>
+      <Route path='/' element={<Navigate to='/전체' />} />
+      <Route path='/:id' element={<ChartPage />} />
+    </>
+  )
+);
+export default router;

--- a/src/types/chartTypes.ts
+++ b/src/types/chartTypes.ts
@@ -1,0 +1,13 @@
+export interface IChartSingleObject {
+  id: string;
+  value_area: number;
+  value_bar: number;
+}
+
+export interface IChartNestedObjects {
+  [key: string]: {
+    id: string;
+    value_area: number;
+    value_bar: number;
+  };
+}

--- a/src/types/chartTypes.ts
+++ b/src/types/chartTypes.ts
@@ -1,13 +1,12 @@
-export interface IChartSingleObject {
+export type ChartData = {
+  dateTimeArray: string[];
+  idArray: string[];
+  areaArray: number[];
+  barArray: number[];
+};
+
+export type ItemData = {
   id: string;
   value_area: number;
   value_bar: number;
-}
-
-export interface IChartNestedObjects {
-  [key: string]: {
-    id: string;
-    value_area: number;
-    value_bar: number;
-  };
-}
+};

--- a/src/types/chartTypes.ts
+++ b/src/types/chartTypes.ts
@@ -1,8 +1,22 @@
 export type ChartData = {
   dateTimeArray: string[];
   idArray: string[];
-  areaArray: number[];
-  barArray: number[];
+  areaArray: YAxisData[];
+  barArray: YAxisData[];
+};
+
+export type YAxisData = {
+  x: string;
+  y: number;
+  fillColor: string;
+};
+
+export type ChartProps = {
+  dateTimeArray: string[];
+  idArray: string[];
+  barArrayState: YAxisData[];
+  areaArrayState: YAxisData[];
+  handleFilter: (id: string) => void;
 };
 
 export type ItemData = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "es6",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## 요구 사항

https://user-images.githubusercontent.com/110284486/225786921-c85b515c-c6c5-4af9-be7f-3b5d21182e32.mp4

- [X] mock data의 key값(시간)을 기반으로 시계열 차트 구현
- [X] Area, Bar 형태가 합쳐진 복합 그래프 형태
- [X] 데이터 구역에 마우스 호버 시 id, value_area, value_bar 데이터를 툴팁 형태로 제공
- [X] 버튼과 데이터 클릭 시 특정 데이터를 하이라이트 하는 필터링 기능 구현

<br/>

## 구현 방법
- 커스텀이 자유로운 apexcharts 라이브러리 사용
- API 호출 및 응답 데이터 가공 처리 함수는 useChartData() custom hook으로 구현
- chartTypes.ts 파일 분리
- 차트 페이지와 차트, 툴팁 컴포넌트를 분리하여 UI 수정이 용이하도록 함
- fillColor 속성을 사용하여 선택된 데이터의 색 변경

<br/>

## 궁금한 사항
1. ChartPage에서 useChartData 훅을 사용하여 데이터를 가져오고, 필터 기능 때문에 한번 더 useState에 데이터를 저장하고 있습니다. 즉 훅에서도 한 번, 페이지에서도 한 번 useState를 사용하고 있는데 혹시 불필요하게 useState를 사용하고 있는 부분이 있는지 궁금합니다.

2. area 차트 영역을 하이라이트 하는 방법을 찾지 못해 마커 색을 변경하는 방식을 적용하게 되었습니다. 혹시 알고 계신 방법이 있다면 공유 부탁드려요!

3.  타입을 다른 파일로 분리할 때 어떤 기준을 적용하는 것이 좋을지 궁금합니다. 같은 파일 안에 있을 때 가독성이 더 좋아지는 경우도 있는 것 같아서 궁금했습니다! 여러분은 어떻게 하고 계신가요?

<br/>

## 추후 보완 사항

- [x] 필터 기능에 라우팅을 적용하여 페이지 이동 시, url로 차트 공유 시 동일하게 필터링 된 차트를 확인할 수 있도록 하기
- [x] css 작업
  - 특정 데이터가 하이라이트 되었을 때 해당하지 않는 데이터 색상을 흑백으로 변경
  - 버튼 컴포넌트 분리 및 url에 따라 버튼 색상이 변경되도록 하여 현재 어떤 지역의 데이터를 하이라이트 하고 있는지 확인하기 쉽도록 함
  - 헤더 추가
- [ ] 필터링 로직을 hook으로 분리하여 유지보수성 향상
